### PR TITLE
Add attention drop detection

### DIFF
--- a/app_to_be_modified.txt
+++ b/app_to_be_modified.txt
@@ -43,6 +43,7 @@ import statistics
 from collections import deque
 import scipy.stats as stats
 from streamlit_autorefresh import st_autorefresh
+from attention_drop import find_attention_drop_point
 
 # ============================================================================
 # STREAMLIT CONFIGURATION
@@ -1496,7 +1497,28 @@ def render_results():
     fig = generate_professional_realtime_chart(st.session_state.session_data)
     if fig:
         st.plotly_chart(fig, use_container_width=True)
-    
+
+    # Attention drop detection
+    drop_info = find_attention_drop_point(st.session_state.session_data)
+    if drop_info:
+        st.markdown("### 📉 Attention Drop Moment")
+        st.info(
+            f"Audience attention decreased around **{drop_info['timestamp']}** "
+            f"with a score of {drop_info['score']:.1f}/5."
+        )
+        timestamps = [d['timestamp'] for d in st.session_state.session_data]
+        idx = st.selectbox(
+            "Select presentation moment",
+            options=list(range(len(timestamps))),
+            format_func=lambda i: timestamps[i],
+            index=drop_info['index'] if drop_info['index'] < len(timestamps) else 0,
+        )
+        point = st.session_state.session_data[idx]
+        st.write(
+            f"**{point['timestamp']}** - Score: {point['score']:.1f}/5 | "
+            f"Label: {point.get('label', 'N/A')}"
+        )
+
     # Export options
     st.markdown("### 💾 Export & Reporting")
     col1, col2, col3, col4 = st.columns(4)

--- a/attention_drop.py
+++ b/attention_drop.py
@@ -1,0 +1,40 @@
+import numpy as np
+from typing import List, Dict, Optional
+
+
+def find_attention_drop_point(session_data: List[Dict], threshold: float = 0.5) -> Optional[Dict]:
+    """Find the moment where engagement experienced the biggest drop.
+
+    Parameters
+    ----------
+    session_data : List[Dict]
+        List containing session entries with at least a ``score`` and ``timestamp`` field.
+    threshold : float, optional
+        Minimum score difference considered a drop. Defaults to ``0.5``.
+
+    Returns
+    -------
+    Optional[Dict]
+        ``None`` if no drop could be determined, otherwise a dictionary with the
+        keys ``index``, ``timestamp`` and ``score`` of the drop moment.
+    """
+    if not session_data or len(session_data) < 2:
+        return None
+
+    scores = [point.get("score", 0) for point in session_data]
+    diffs = np.diff(scores)
+    drop_index = int(np.argmin(diffs)) + 1  # index after the drop
+    drop_value = diffs[drop_index - 1]
+
+    if drop_value < -threshold:
+        drop_point = session_data[drop_index]
+    else:
+        # no significant drop, use lowest scoring moment
+        drop_index = int(np.argmin(scores))
+        drop_point = session_data[drop_index]
+
+    return {
+        "index": drop_index,
+        "timestamp": drop_point.get("timestamp"),
+        "score": drop_point.get("score"),
+    }


### PR DESCRIPTION
## Summary
- detect attention drop moment based on engagement scores
- highlight drop point in results view with a selector

## Testing
- `python -m py_compile attention_drop.py app_to_be_modified.txt`

------
https://chatgpt.com/codex/tasks/task_e_686aa62658f8832aa6af34c0664dcca7