### PR TITLE
Add attention drop moment selection

### DIFF
--- a/app_to_be_modified.txt
+++ b/app_to_be_modified.txt
@@ -43,6 +43,7 @@ import statistics
 from collections import deque
 import scipy.stats as stats
 from streamlit_autorefresh import st_autorefresh
+from attention_drop import find_attention_drop_moment
 
 # ============================================================================
 # STREAMLIT CONFIGURATION
@@ -1494,8 +1495,31 @@ def render_results():
     # Enhanced chart
     st.markdown("### 📊 Engagement Analysis (0-5 Scale)")
     fig = generate_professional_realtime_chart(st.session_state.session_data)
+    drop_info = find_attention_drop_moment(
+        st.session_state.session_data,
+        method="largest-drop",
+        threshold=0.5,
+    )
     if fig:
+        if drop_info:
+            fig.add_vline(x=drop_info["index"], line_color="#ef4444", line_dash="dash")
         st.plotly_chart(fig, use_container_width=True)
+
+    if drop_info:
+        st.markdown(
+            f"**Lowest attention at {drop_info['timestamp']} (score {drop_info['score']:.1f}/5)**"
+        )
+        max_idx = len(st.session_state.session_data) - 1
+        selected_idx = st.slider(
+            "Select presentation moment",
+            0,
+            max_idx,
+            drop_info["index"],
+        )
+        selected = st.session_state.session_data[selected_idx]
+        st.write(
+            f"Selected time: {selected['timestamp']} – Score: {selected['score']:.1f}/5"
+        )
     
     # Export options
     st.markdown("### 💾 Export & Reporting")

--- a/attention_drop.py
+++ b/attention_drop.py
@@ -1,0 +1,41 @@
+import numpy as np
+from typing import List, Dict, Optional
+
+
+def find_attention_drop_moment(session_data: List[Dict], *, method: str = "min", threshold: float = 0.5) -> Optional[Dict]:
+    """Return information about the moment where engagement dropped.
+
+    Parameters
+    ----------
+    session_data : list of dict
+        Collection of data points with a ``score`` field and ``timestamp``.
+    method : {"min", "largest-drop"}
+        How to determine the drop moment. ``"min"`` returns the lowest score
+        in the session while ``"largest-drop"`` looks for the biggest
+        decrease between consecutive scores.
+    threshold : float
+        Minimum drop amount when ``method`` is ``"largest-drop"``.
+
+    Returns
+    -------
+    dict or None
+        A dictionary with ``index``, ``timestamp`` and ``score`` of the drop
+        moment, or ``None`` if it cannot be determined.
+    """
+    if not session_data:
+        return None
+
+    scores = [d.get("score", 0) for d in session_data]
+
+    if method == "largest-drop" and len(scores) > 1:
+        diffs = np.diff(scores)
+        drop_idx = int(np.argmin(diffs))
+        if diffs[drop_idx] < -abs(threshold):
+            idx = drop_idx + 1
+        else:
+            idx = int(np.argmin(scores))
+    else:
+        idx = int(np.argmin(scores))
+
+    entry = session_data[idx]
+    return {"index": idx, "timestamp": entry.get("timestamp"), "score": entry.get("score")}


### PR DESCRIPTION
## Summary
- implement attention drop detection helper
- visualize the lowest attention point in the engagement results
- allow user to select a specific moment of the presentation on the results page

## Testing
- `python -m py_compile attention_drop.py`
- `python -m py_compile app_to_be_modified.txt`

------
https://chatgpt.com/codex/tasks/task_e_686aa62658f8832aa6af34c0664dcca7